### PR TITLE
Prevent articles from being marked as onepage_article without addNavigation being set.

### DIFF
--- a/src/Hooks/OnepageHooks.php
+++ b/src/Hooks/OnepageHooks.php
@@ -20,10 +20,12 @@ class OnepageHooks extends Controller
     public function onGetArticle($row): void
     {
         if ($anchor = $row->navigation_jumpTo) {
-            $cssId      = StringUtil::deserialize($row->cssID, true);
-            $cssId[0]   = $anchor;
-            $cssId[1]  .= ' onepage_article';
-            $row->cssID = serialize($cssId);
+	    if($row->addNavigation) {
+                $cssId      = StringUtil::deserialize($row->cssID, true);
+                $cssId[0]   = $anchor;
+                $cssId[1]  .= ' onepage_article';
+                $row->cssID = serialize($cssId);
+	    }
         }
     }
 


### PR DESCRIPTION
Bug: Hook setzt die Klasse "onepage_article" wenn jumpTo vorhanden ist aber kein addNavigation gesetzt wurde.

Das Problem tritt auf bei Artikeln in dem die Checkbox "Als Navigationspunkt hinzufügen" nicht gesetzt ist aber das Feld "Sprungmarke" eine Angabe enthält. Passt z.B. beim kopieren eines Artikels. 

Im Hook onGetArticle wird nur der Inhalt der Sprungmarke geprüft und die zusätzliche Klasse "onepage_article" dann hinzugefügt obwohl die oben genannte Checkbox deaktiviert ist. Das hat zur Folge das ein Javasrcipt-Fehler im FE entsteht der die Artikelnavigation unbrauchbar macht.

Eine zusätzliche Abfrage verhindert das setzen der Klasse.