### PR TITLE
Fix: specify VARCHAR length for navigation fields to support doctrine…

### DIFF
--- a/contao/dca/tl_article.php
+++ b/contao/dca/tl_article.php
@@ -54,6 +54,7 @@ $GLOBALS['TL_DCA']['tl_article']['fields']['navigation_title'] = [
     ],
     'sql' => [
         'type' => 'string',
+        'length' => 255,
         'default' => '',
     ],
 ];
@@ -69,6 +70,7 @@ $GLOBALS['TL_DCA']['tl_article']['fields']['navigation_jumpTo'] = [
     ],
     'sql' => [
         'type' => 'string',
+        'length' => 255,
         'default' => '',
     ],
 ];


### PR DESCRIPTION
Doctrine DBAL removed hard-coded default lengths for VARCHAR columns (doctrine/dbal#3586). Without an explicit `length`, MariaDB 10.7+ and related platforms throw `ColumnLengthRequired`.

This PR adds `length => 255` to `navigation_title` and `navigation_jumpTo` fields in tl_article to ensure compatibility and 
resolves issue #37.