### PR TITLE
Fix active one-page nav marker with dynamic section heights

### DIFF
--- a/public/onepage_navigation.js
+++ b/public/onepage_navigation.js
@@ -119,7 +119,16 @@ function Onepage(list, options) {
 
     window.addEventListener('scroll', requestActiveUpdate, { passive: true });
     window.addEventListener('resize', requestActiveUpdate);
-    document.addEventListener('toggle', requestActiveUpdate, true);
+
+    if (typeof ResizeObserver !== 'undefined') {
+        const resizeObserver = new ResizeObserver(() => {
+            requestActiveUpdate();
+        });
+
+        articles.forEach((article) => {
+            resizeObserver.observe(article);
+        });
+    }
 
     // initial state
     requestActiveUpdate();

--- a/public/onepage_navigation.js
+++ b/public/onepage_navigation.js
@@ -73,15 +73,72 @@ function Onepage(list, options) {
         }
     };
 
-    const articleObserver = new IntersectionObserver (function (entries, observer) {
-        entries.forEach(function(entry) {
-            if (entry.isIntersecting) {
-                navActive(entry.target.id);
+    const getActiveArticleByPosition = () => {
+        if (!articles.length) {
+            return null;
+        }
+
+        const activationPoint = (window.innerHeight * offset) / 100;
+        let candidate = null;
+
+        articles.forEach((article) => {
+            const rect = article.getBoundingClientRect();
+
+            if (rect.top <= activationPoint) {
+                if (candidate === null || rect.top > candidate.rectTop) {
+                    candidate = {
+                        id: article.id,
+                        rectTop: rect.top
+                    };
+                }
             }
         });
+
+        return candidate ? candidate.id : articles[0].id;
+    };
+
+    const updateActiveArticle = () => {
+        const activeArticle = getActiveArticleByPosition();
+
+        if (activeArticle) {
+            navActive(activeArticle);
+        }
+    };
+
+    let ticking = false;
+    const requestActiveUpdate = () => {
+        if (ticking) {
+            return;
+        }
+
+        ticking = true;
+        window.requestAnimationFrame(() => {
+            updateActiveArticle();
+            ticking = false;
+        });
+    };
+
+    const articleObserver = new IntersectionObserver (function () {
+        requestActiveUpdate();
     }, { rootMargin: offsetArray });
 
-    articles.forEach ((article) => {
+    articles.forEach((article) => {
         articleObserver.observe(article);
     });
+
+    if (typeof ResizeObserver !== 'undefined') {
+        const resizeObserver = new ResizeObserver(() => {
+            requestActiveUpdate();
+        });
+
+        articles.forEach((article) => {
+            resizeObserver.observe(article);
+        });
+    }
+
+    window.addEventListener('scroll', requestActiveUpdate, { passive: true });
+    window.addEventListener('resize', requestActiveUpdate);
+
+    // initial state
+    requestActiveUpdate();
 };

--- a/public/onepage_navigation.js
+++ b/public/onepage_navigation.js
@@ -4,7 +4,6 @@ function Onepage(list, options) {
     const pushUrl = options.pushUrl || false;
     const offset = parseInt(options.offset, 10) || 0;
 
-    const offsetArray = Number(-offset) + '% 0% '+  Number(-offset) + '% 0%';
     const el = document.querySelectorAll('a[href*="#"]:not([href="#"]):not([href="#0"]):not(.invisible)');
     const uri = window.location.href.split("#")[0];
 
@@ -118,26 +117,9 @@ function Onepage(list, options) {
         });
     };
 
-    const articleObserver = new IntersectionObserver (function () {
-        requestActiveUpdate();
-    }, { rootMargin: offsetArray });
-
-    articles.forEach((article) => {
-        articleObserver.observe(article);
-    });
-
-    if (typeof ResizeObserver !== 'undefined') {
-        const resizeObserver = new ResizeObserver(() => {
-            requestActiveUpdate();
-        });
-
-        articles.forEach((article) => {
-            resizeObserver.observe(article);
-        });
-    }
-
     window.addEventListener('scroll', requestActiveUpdate, { passive: true });
     window.addEventListener('resize', requestActiveUpdate);
+    document.addEventListener('toggle', requestActiveUpdate, true);
 
     // initial state
     requestActiveUpdate();


### PR DESCRIPTION
## Summary
- recalculate the active navigation item from current section geometry instead of relying on single intersection events
- trigger active state updates on scroll/resize and when section heights change (`ResizeObserver`)
- keep `IntersectionObserver` as lightweight trigger, but make final active selection deterministic

## Why
When content inside a section changes height dynamically (e.g. opening an accordion), multiple sections can become intersecting in quick succession. The previous logic could mark later menu items as active too early.

## Fix
We now pick the section whose top is closest to the configured offset line in the viewport. That makes the active marker stable even when section heights change after initial render.

Closes #34