### PR TITLE
Fix onepage anchors on reader pages

### DIFF
--- a/src/Controller/FrontendModule/OnepageNavigationController.php
+++ b/src/Controller/FrontendModule/OnepageNavigationController.php
@@ -48,12 +48,7 @@ class OnepageNavigationController extends AbstractFrontendModuleController
             $pageId = $objPage->id;
         } else {
             $objPage = $this->getPageModel();
-
-            if ('error_404' === $objPage->type) {
-                $pageAlias = $objPage->alias;
-            } else {
-                $pageAlias = $this->contentUrlGenerator->generate($objPage);
-            }
+            $pageAlias = $request->getRequestUri();
         }
 
         // get articles by page id


### PR DESCRIPTION
## Summary
- preserve auto_item/detail URLs for onepage navigation links on current-page modules
- use the current request URI in the non-defineRoot branch instead of regenerating the plain page URL
- remove the obsolete error_404 special case from that branch

## Testing
- php -l src/Controller/FrontendModule/OnepageNavigationController.php

This fixes broken anchor links on reader/detail pages where ContentUrlGenerator drops the current route's auto_item alias.